### PR TITLE
Mccalluc/respect prefixes

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -15,6 +15,7 @@ plugins:
   - react
 rules:
   no-console: [2, { "allow": ["warn", "error"]}]
+  no-underscore-dangle: [0] # We use it to mark privates, which are shared for testing.
   react/jsx-filename-extension: [0]
   react/sort-comp: [0]  # Non-alphabetical groupings can make more sense.
   react/jsx-one-expression-per-line: [0]  # Makes punctuation after tab awkward.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.0.3 - in progress
 ### Changed
 - Fixed redundant fixtures.
+- Namespace prefixes are arbitrary: This expands them to the URIs they represent.
 
 ## [0.0.2](https://www.npmjs.com/package/@hubmap/prov-vis/v/0.0.2) - 2019-11-04
 ### Added

--- a/src/Prov.js
+++ b/src/Prov.js
@@ -79,17 +79,6 @@ export function _expand(needsExpansion, prefixMap, onlyExpandKeysNext, onlyExpan
   );
 }
 
-export function _expandKeys(needsExpansion, prefixMap) {
-  return Object.fromEntries(
-    Object.entries(needsExpansion).map(
-      ([key, value]) => {
-        const [prefix, stem] = key.split(':');
-        return [prefixMap[prefix] + stem, value];
-      },
-    ),
-  );
-}
-
 export default class Prov {
   constructor(prov, getNameForActivity = (id) => id, getNameForEntity = (id) => id) {
     this.getNameForActivity = getNameForActivity;

--- a/src/Prov.js
+++ b/src/Prov.js
@@ -3,7 +3,7 @@ import Ajv from 'ajv';
 import schema from './schema.json';
 
 // export only to test.
-export function makeCwlInput(name, steps, extras, isReference) {
+export function _makeCwlInput(name, steps, extras, isReference) {
   const id = name;
   const source = [{
     name,
@@ -32,7 +32,7 @@ export function makeCwlInput(name, steps, extras, isReference) {
 }
 
 // export only to test.
-export function makeCwlOutput(name, steps, extras) {
+export function _makeCwlOutput(name, steps, extras) {
   const id = name;
   return {
     name,
@@ -50,7 +50,7 @@ export function makeCwlOutput(name, steps, extras) {
   };
 }
 
-export function expand(needsExpansion, prefixMap) {
+export function _expand(needsExpansion, prefixMap) {
   // Walk the needsExpansion object, using prefixMap to expand the keys.
   if (typeof needsExpansion !== 'object') {
     const [prefix, stem] = needsExpansion.split(':');
@@ -64,7 +64,7 @@ export function expand(needsExpansion, prefixMap) {
       Object.entries(needsExpansion).map(
         ([key, value]) => {
           const [prefix, stem] = key.split(':');
-          return [prefixMap[prefix] + stem, expand(value, prefixMap)]
+          return [prefixMap[prefix] + stem, _expand(value, prefixMap)]
         }
       )
     );
@@ -141,13 +141,13 @@ export default class Prov {
     const activityName = this.getNameForActivity(activityId, this.prov);
     const inputs = this.getParentEntityNames(activityName)
       .map(
-        (entityName) => makeCwlInput(
+        (entityName) => _makeCwlInput(
           entityName, this.getParentActivityNames(entityName), this.entityByName[entityName],
         ),
       );
     const outputs = this.getChildEntityNames(activityName)
       .map(
-        (entityName) => makeCwlOutput(
+        (entityName) => _makeCwlOutput(
           entityName, this.getChildActivityNames(entityName), this.entityByName[entityName],
         ),
       );

--- a/src/Prov.js
+++ b/src/Prov.js
@@ -92,7 +92,7 @@ export default class Prov {
       const needsExpansion = this.prov[topLevel];
       expandedProv[topLevel] = _expand(needsExpansion, this.prov.prefix);
     });
-    return new Prov(expandedProv);
+    return new Prov(expandedProv, this.getNameForActivity, this.getNameForEntity);
   }
 
 

--- a/src/Prov.js
+++ b/src/Prov.js
@@ -72,7 +72,7 @@ export function _expand(needsExpansion, prefixMap, onlyExpandKeysNext, onlyExpan
           prefixMap[prefix] + stem,
           onlyExpandKeys
             ? value
-            : _expand(value, prefixMap, false, onlyExpandKeysNext)
+            : _expand(value, prefixMap, false, onlyExpandKeysNext),
         ];
       },
     ),
@@ -102,7 +102,7 @@ export default class Prov {
       throw new Error(failureReason);
     }
     this.prov = prov;
-    this.prov.prefix._ = '[anonymous]'
+    this.prov.prefix._ = '[anonymous]';
   }
 
   expandPrefixes() {
@@ -112,10 +112,9 @@ export default class Prov {
       const mayNeedExpansion = this.prov[topLevel];
       expandedProv[topLevel] = _expand(
         mayNeedExpansion, this.prov.prefix,
-        topLevel === 'entity' || topLevel === 'activity'
+        topLevel === 'entity' || topLevel === 'activity',
       );
     });
-    console.log(JSON.stringify(expandedProv, null, 2));
     return new Prov(expandedProv, this.getNameForActivity, this.getNameForEntity);
   }
 

--- a/src/Prov.js
+++ b/src/Prov.js
@@ -2,7 +2,7 @@ import Ajv from 'ajv';
 
 import schema from './schema.json';
 
-const PROV_NS = 'http://www.w3.org/ns/prov#';
+export const PROV_NS = 'http://www.w3.org/ns/prov#';
 
 // export only to test.
 export function _makeCwlInput(name, steps, extras, isReference) {
@@ -73,8 +73,8 @@ export function _expand(needsExpansion, prefixMap) {
 
 export default class Prov {
   constructor(prov, getNameForActivity = (id) => id, getNameForEntity = (id) => id) {
-    this._getNameForActivity = getNameForActivity;
-    this._getNameForEntity = getNameForEntity;
+    this.getNameForActivity = getNameForActivity;
+    this.getNameForEntity = getNameForEntity;
 
     const validate = new Ajv().compile(schema);
     const valid = validate(prov);
@@ -98,8 +98,8 @@ export default class Prov {
 
   _getEntityNames(activityName, relation) {
     return Object.values(this.prov[relation])
-      .filter((pair) => this._getNameForActivity(pair[`${PROV_NS}activity`], this.prov) === activityName)
-      .map((pair) => this._getNameForEntity(pair[`${PROV_NS}entity`], this.prov));
+      .filter((pair) => this.getNameForActivity(pair[`${PROV_NS}activity`], this.prov) === activityName)
+      .map((pair) => this.getNameForEntity(pair[`${PROV_NS}entity`], this.prov));
   }
 
   _getParentEntityNames(activityName) {
@@ -112,8 +112,8 @@ export default class Prov {
 
   _getActivityNames(entityName, relation) {
     return Object.values(this.prov[relation])
-      .filter((pair) => this._getNameForEntity(pair[`${PROV_NS}entity`], this.prov) === entityName)
-      .map((pair) => this._getNameForActivity(pair[`${PROV_NS}activity`], this.prov));
+      .filter((pair) => this.getNameForEntity(pair[`${PROV_NS}entity`], this.prov) === entityName)
+      .map((pair) => this.getNameForActivity(pair[`${PROV_NS}activity`], this.prov));
   }
 
   _getParentActivityNames(entityName) {
@@ -128,11 +128,11 @@ export default class Prov {
   makeCwlStep(activityId) {
     const entityByName = Object.fromEntries(
       Object.entries(this.prov.entity).map(([entityId, entity]) => [
-        this._getNameForEntity(entityId, this.prov), entity,
+        this.getNameForEntity(entityId, this.prov), entity,
       ]),
     );
 
-    const activityName = this._getNameForActivity(activityId, this.prov);
+    const activityName = this.getNameForActivity(activityId, this.prov);
     const inputs = this._getParentEntityNames(activityName)
       .map(
         (entityName) => _makeCwlInput(

--- a/src/Prov.js
+++ b/src/Prov.js
@@ -92,9 +92,11 @@ export default class Prov {
     }
     this.prov = prov;
     this.prov.prefix._ = '[anonymous]';
+
+    this._expandPrefixes();
   }
 
-  expandPrefixes() {
+  _expandPrefixes() {
     // Returns a new Prov object, with NS prefixes expanded.
     const expandedProv = { prefix: {} };
     Object.keys(this.prov).filter((k) => k !== 'prefix').forEach((topLevel) => {
@@ -104,7 +106,7 @@ export default class Prov {
         topLevel === 'entity' || topLevel === 'activity',
       );
     });
-    return new Prov(expandedProv, this.getNameForActivity, this.getNameForEntity);
+    this.prov = expandedProv;
   }
 
 

--- a/src/Prov.js
+++ b/src/Prov.js
@@ -53,7 +53,12 @@ export function makeCwlOutput(name, steps, extras) {
 export function expand(needsExpansion, prefixMap) {
   // Walk the needsExpansion object, using prefixMap to expand the keys.
   if (typeof needsExpansion !== 'object') {
-    return needsExpansion;
+    const [prefix, stem] = needsExpansion.split(':');
+    if (stem) {
+      return prefixMap[prefix] + stem;
+    } else {
+      return prefix;
+    }
   } else {
     return Object.fromEntries(
       Object.entries(needsExpansion).map(

--- a/src/ProvVis.js
+++ b/src/ProvVis.js
@@ -10,7 +10,7 @@ export default function ProvVis(props) {
   } = props;
   const steps = new Prov(
     prov, getNameForActivity, getNameForEntity,
-  ).expandPrefixes().toCwl();
+  ).toCwl();
   function renderDetailPaneWithNode(node) { // eslint-disable-line consistent-return
     if (renderDetailPane && node) {
       return renderDetailPane(node.meta.prov);

--- a/src/ProvVis.js
+++ b/src/ProvVis.js
@@ -8,7 +8,9 @@ export default function ProvVis(props) {
   const {
     prov, getNameForActivity, getNameForEntity, renderDetailPane,
   } = props;
-  const steps = new Prov(prov, getNameForActivity, getNameForEntity).toCwl();
+  const steps = new Prov(
+    prov, getNameForActivity, getNameForEntity
+  ).expandPrefixes().toCwl();
   function renderDetailPaneWithNode(node) { // eslint-disable-line consistent-return
     if (renderDetailPane && node) {
       return renderDetailPane(node.meta.prov);

--- a/src/ProvVis.js
+++ b/src/ProvVis.js
@@ -9,7 +9,7 @@ export default function ProvVis(props) {
     prov, getNameForActivity, getNameForEntity, renderDetailPane,
   } = props;
   const steps = new Prov(
-    prov, getNameForActivity, getNameForEntity
+    prov, getNameForActivity, getNameForEntity,
   ).expandPrefixes().toCwl();
   function renderDetailPaneWithNode(node) { // eslint-disable-line consistent-return
     if (renderDetailPane && node) {

--- a/tests/Prov.test.js
+++ b/tests/Prov.test.js
@@ -33,80 +33,35 @@ describe('Prov errors', () => {
 
 describe('Prov methods', () => {
   const prov = new Prov(
-    fixtures.complex.prov,
-    (id) => `ACT-${id}`,
-    (id) => `ENT-${id}`,
-  );
+    fixtures.complex.prov
+  ).expandPrefixes();
 
   it('getParentEntityNames', () => {
-    expect(prov._getParentEntityNames('ACT-hubmap:act-4')).toEqual([
-      'ENT-hubmap:ent-1', 'ENT-hubmap:ent-3', 'ENT-hubmap:ent-4',
+    expect(prov._getParentEntityNames('https://hubmapconsortium.org/act-4')).toEqual([
+      'https://hubmapconsortium.org/ent-1',
+      'https://hubmapconsortium.org/ent-3',
+      'https://hubmapconsortium.org/ent-4',
     ]);
   });
 
   it('getChildEntityNames', () => {
-    expect(prov._getChildEntityNames('ACT-hubmap:act-2')).toEqual([
-      'ENT-hubmap:ent-4', 'ENT-hubmap:ent-7',
+    expect(prov._getChildEntityNames('https://hubmapconsortium.org/act-2')).toEqual([
+      'https://hubmapconsortium.org/ent-4', 'https://hubmapconsortium.org/ent-7',
     ]);
   });
 
   it('getParentActivityNames', () => {
-    expect(prov._getParentActivityNames('ENT-hubmap:ent-6')).toEqual([
-      'ACT-hubmap:act-4',
+    expect(prov._getParentActivityNames('https://hubmapconsortium.org/ent-6')).toEqual([
+      'https://hubmapconsortium.org/act-4',
     ]);
   });
 
   it('getChildActivityNames', () => {
-    expect(prov._getChildActivityNames('ENT-hubmap:ent-1')).toEqual([
-      'ACT-hubmap:act-1', 'ACT-hubmap:act-2', 'ACT-hubmap:act-4',
+    expect(prov._getChildActivityNames('https://hubmapconsortium.org/ent-1')).toEqual([
+      'https://hubmapconsortium.org/act-1',
+      'https://hubmapconsortium.org/act-2',
+      'https://hubmapconsortium.org/act-4',
     ]);
-  });
-
-  it('has activityByName', () => {
-    expect(prov.activityByName).toEqual(
-      {
-        'ACT-hubmap:act-1': {
-          'prov:label': 'act-1',
-        },
-        'ACT-hubmap:act-2': {
-          'prov:label': 'act-2',
-        },
-        'ACT-hubmap:act-3': {
-          'prov:label': 'act-3',
-        },
-        'ACT-hubmap:act-4': {
-          'prov:label': 'act-4',
-        },
-      },
-    );
-  });
-
-  it('has entityByName', () => {
-    expect(prov.entityByName).toEqual(
-      {
-        'ENT-hubmap:ent-1': {
-          'prov:label': 'ent-1',
-        },
-        'ENT-hubmap:ent-2': {
-          'prov:label': 'ent-2',
-        },
-        'ENT-hubmap:ent-3': {
-          'prov:label': 'ent-3',
-        },
-        'ENT-hubmap:ent-4': {
-          'prov:label': 'ent-4',
-        },
-        'ENT-hubmap:ent-5': {
-          'prov:label': 'ent-5',
-        },
-        'ENT-hubmap:ent-6': {
-          'prov:label': 'ent-6',
-        },
-        'ENT-hubmap:ent-7': {
-          'prov:label': 'ent-7',
-        },
-      },
-    );
   });
 });
 

--- a/tests/Prov.test.js
+++ b/tests/Prov.test.js
@@ -111,7 +111,22 @@ describe('Prov methods', () => {
 });
 
 describe('PROV expansion', () => {
-  expect(expand({})).toEqual({});
+  it('should expand prefixes', () =>{
+    expect(
+      expand({
+        'do:C': { 're:D': 'mi:E' },
+        're:D': { 're:D': 'not-expanded' }
+      },
+      {
+        do: 'deer#',
+        re: 'drop-of-golden-sun#',
+        mi: 'name-i-call-myself#'
+      }
+    )).toEqual({
+      'deer#C': { 'drop-of-golden-sun#D': 'name-i-call-myself#E' },
+      'drop-of-golden-sun#D': { 'drop-of-golden-sun#D': 'not-expanded' }
+    })
+  });
 })
 
 describe('cwl utils', () => {

--- a/tests/Prov.test.js
+++ b/tests/Prov.test.js
@@ -8,8 +8,7 @@ import * as fixtures from './fixtures';
 describe('Prov fixtures', () => {
   Object.entries(fixtures).forEach(([k, v]) => {
     it(`converts ${k} W3C JSON to 4DN CWL`, () => {
-      const prov = new Prov(v.prov, v.getNameForActivity, v.getNameForEntity);
-      const cwl = prov.expandPrefixes().toCwl();
+      const cwl = new Prov(v.prov, v.getNameForActivity, v.getNameForEntity).toCwl();
       expect(cwl).toEqual(v.cwl, `Mismatch (full after diff):\n${JSON.stringify(cwl, null, 2)}`);
     });
   });
@@ -34,7 +33,7 @@ describe('Prov errors', () => {
 describe('Prov methods', () => {
   const prov = new Prov(
     fixtures.complex.prov,
-  ).expandPrefixes();
+  );
 
   it('getParentEntityNames', () => {
     expect(prov._getParentEntityNames('https://hubmapconsortium.org/act-4')).toEqual([

--- a/tests/Prov.test.js
+++ b/tests/Prov.test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 
-import Prov, { makeCwlInput, makeCwlOutput } from '../src/Prov';
+import Prov, { makeCwlInput, makeCwlOutput, expand } from '../src/Prov';
 
 import * as fixtures from './fixtures';
 
@@ -109,6 +109,10 @@ describe('Prov methods', () => {
     );
   });
 });
+
+describe('PROV expansion', () => {
+  expect(expand({})).toEqual({});
+})
 
 describe('cwl utils', () => {
   it('makeCwlInput reference', () => {

--- a/tests/Prov.test.js
+++ b/tests/Prov.test.js
@@ -9,7 +9,7 @@ describe('Prov fixtures', () => {
   Object.entries(fixtures).forEach(([k, v]) => {
     it(`converts ${k} W3C JSON to 4DN CWL`, () => {
       const prov = new Prov(v.prov, v.getNameForActivity, v.getNameForEntity);
-      const cwl = prov.toCwl();
+      const cwl = prov.expandPrefixes().toCwl();
       expect(cwl).toEqual(v.cwl, `Mismatch (full after diff):\n${JSON.stringify(cwl, null, 2)}`);
     });
   });

--- a/tests/Prov.test.js
+++ b/tests/Prov.test.js
@@ -33,7 +33,7 @@ describe('Prov errors', () => {
 
 describe('Prov methods', () => {
   const prov = new Prov(
-    fixtures.complex.prov
+    fixtures.complex.prov,
   ).expandPrefixes();
 
   it('getParentEntityNames', () => {
@@ -66,23 +66,23 @@ describe('Prov methods', () => {
 });
 
 describe('PROV expansion', () => {
-  it('should expand prefixes', () =>{
+  it('should expand prefixes', () => {
     expect(
       _expand({
         'do:C': { 're:D': 'mi:E' },
-        're:D': { 're:D': 'not-expanded' }
+        're:D': { 're:D': 'not-expanded' },
       },
       {
         do: 'deer#',
         re: 'drop-of-golden-sun#',
-        mi: 'name-i-call-myself#'
-      }
-    )).toEqual({
+        mi: 'name-i-call-myself#',
+      }),
+    ).toEqual({
       'deer#C': { 'drop-of-golden-sun#D': 'name-i-call-myself#E' },
-      'drop-of-golden-sun#D': { 'drop-of-golden-sun#D': 'not-expanded' }
-    })
+      'drop-of-golden-sun#D': { 'drop-of-golden-sun#D': 'not-expanded' },
+    });
   });
-})
+});
 
 describe('CWL utils', () => {
   it('_makeCwlInput reference', () => {

--- a/tests/Prov.test.js
+++ b/tests/Prov.test.js
@@ -39,25 +39,25 @@ describe('Prov methods', () => {
   );
 
   it('getParentEntityNames', () => {
-    expect(prov.getParentEntityNames('ACT-hubmap:act-4')).toEqual([
+    expect(prov._getParentEntityNames('ACT-hubmap:act-4')).toEqual([
       'ENT-hubmap:ent-1', 'ENT-hubmap:ent-3', 'ENT-hubmap:ent-4',
     ]);
   });
 
   it('getChildEntityNames', () => {
-    expect(prov.getChildEntityNames('ACT-hubmap:act-2')).toEqual([
+    expect(prov._getChildEntityNames('ACT-hubmap:act-2')).toEqual([
       'ENT-hubmap:ent-4', 'ENT-hubmap:ent-7',
     ]);
   });
 
   it('getParentActivityNames', () => {
-    expect(prov.getParentActivityNames('ENT-hubmap:ent-6')).toEqual([
+    expect(prov._getParentActivityNames('ENT-hubmap:ent-6')).toEqual([
       'ACT-hubmap:act-4',
     ]);
   });
 
   it('getChildActivityNames', () => {
-    expect(prov.getChildActivityNames('ENT-hubmap:ent-1')).toEqual([
+    expect(prov._getChildActivityNames('ENT-hubmap:ent-1')).toEqual([
       'ACT-hubmap:act-1', 'ACT-hubmap:act-2', 'ACT-hubmap:act-4',
     ]);
   });

--- a/tests/Prov.test.js
+++ b/tests/Prov.test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 
-import Prov, { makeCwlInput, makeCwlOutput, expand } from '../src/Prov';
+import Prov, { _makeCwlInput, _makeCwlOutput, _expand } from '../src/Prov';
 
 import * as fixtures from './fixtures';
 
@@ -113,7 +113,7 @@ describe('Prov methods', () => {
 describe('PROV expansion', () => {
   it('should expand prefixes', () =>{
     expect(
-      expand({
+      _expand({
         'do:C': { 're:D': 'mi:E' },
         're:D': { 're:D': 'not-expanded' }
       },
@@ -129,9 +129,9 @@ describe('PROV expansion', () => {
   });
 })
 
-describe('cwl utils', () => {
-  it('makeCwlInput reference', () => {
-    expect(makeCwlInput('name1', [], { extras: 'go here!' }, true)).toEqual(
+describe('CWL utils', () => {
+  it('_makeCwlInput reference', () => {
+    expect(_makeCwlInput('name1', [], { extras: 'go here!' }, true)).toEqual(
       {
         meta: {
           global: true,
@@ -157,8 +157,8 @@ describe('cwl utils', () => {
     );
   });
 
-  it('makeCwlInput with step', () => {
-    expect(makeCwlInput('name1', ['step1'], { extras: 'go here!' })).toEqual(
+  it('_makeCwlInput with step', () => {
+    expect(_makeCwlInput('name1', ['step1'], { extras: 'go here!' })).toEqual(
       {
         meta: {
           global: true,
@@ -185,8 +185,8 @@ describe('cwl utils', () => {
     );
   });
 
-  it('makeCwlOutput', () => {
-    expect(makeCwlOutput('name1', ['step1'], { extras: 'go here!' })).toEqual(
+  it('_makeCwlOutput', () => {
+    expect(_makeCwlOutput('name1', ['step1'], { extras: 'go here!' })).toEqual(
       {
         meta: {
           global: true,

--- a/tests/fixtures/complex-cwl.json
+++ b/tests/fixtures/complex-cwl.json
@@ -1,19 +1,19 @@
 [
   {
-    "name": "hubmap:act-1",
+    "name": "https://hubmapconsortium.org/act-1",
     "inputs": [
       {
-        "name": "hubmap:ent-1",
+        "name": "https://hubmapconsortium.org/ent-1",
         "source": [
           {
-            "name": "hubmap:ent-1",
-            "for_file": "hubmap:ent-1"
+            "name": "https://hubmapconsortium.org/ent-1",
+            "for_file": "https://hubmapconsortium.org/ent-1"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "hubmap:ent-1"
+              "@id": "https://hubmapconsortium.org/ent-1"
             }
           ]
         },
@@ -23,27 +23,27 @@
           "type": "data file"
         },
         "prov": {
-          "prov:label": "ent-1"
+          "http://www.w3.org/ns/prov#label": "ent-1"
         }
       }
     ],
     "outputs": [
       {
-        "name": "hubmap:ent-3",
+        "name": "https://hubmapconsortium.org/ent-3",
         "target": [
           {
-            "step": "hubmap:act-3",
-            "name": "hubmap:ent-3"
+            "step": "https://hubmapconsortium.org/act-3",
+            "name": "https://hubmapconsortium.org/ent-3"
           },
           {
-            "step": "hubmap:act-4",
-            "name": "hubmap:ent-3"
+            "step": "https://hubmapconsortium.org/act-4",
+            "name": "https://hubmapconsortium.org/ent-3"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "hubmap:ent-3"
+              "@id": "https://hubmapconsortium.org/ent-3"
             }
           ]
         },
@@ -52,29 +52,29 @@
           "in_path": true
         },
         "prov": {
-          "prov:label": "ent-3"
+          "http://www.w3.org/ns/prov#label": "ent-3"
         }
       }
     ],
     "prov": {
-      "prov:label": "act-1"
+      "http://www.w3.org/ns/prov#label": "act-1"
     }
   },
   {
-    "name": "hubmap:act-2",
+    "name": "https://hubmapconsortium.org/act-2",
     "inputs": [
       {
-        "name": "hubmap:ent-1",
+        "name": "https://hubmapconsortium.org/ent-1",
         "source": [
           {
-            "name": "hubmap:ent-1",
-            "for_file": "hubmap:ent-1"
+            "name": "https://hubmapconsortium.org/ent-1",
+            "for_file": "https://hubmapconsortium.org/ent-1"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "hubmap:ent-1"
+              "@id": "https://hubmapconsortium.org/ent-1"
             }
           ]
         },
@@ -84,21 +84,21 @@
           "type": "data file"
         },
         "prov": {
-          "prov:label": "ent-1"
+          "http://www.w3.org/ns/prov#label": "ent-1"
         }
       },
       {
-        "name": "hubmap:ent-2",
+        "name": "https://hubmapconsortium.org/ent-2",
         "source": [
           {
-            "name": "hubmap:ent-2",
-            "for_file": "hubmap:ent-2"
+            "name": "https://hubmapconsortium.org/ent-2",
+            "for_file": "https://hubmapconsortium.org/ent-2"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "hubmap:ent-2"
+              "@id": "https://hubmapconsortium.org/ent-2"
             }
           ]
         },
@@ -108,23 +108,23 @@
           "type": "data file"
         },
         "prov": {
-          "prov:label": "ent-2"
+          "http://www.w3.org/ns/prov#label": "ent-2"
         }
       }
     ],
     "outputs": [
       {
-        "name": "hubmap:ent-4",
+        "name": "https://hubmapconsortium.org/ent-4",
         "target": [
           {
-            "step": "hubmap:act-4",
-            "name": "hubmap:ent-4"
+            "step": "https://hubmapconsortium.org/act-4",
+            "name": "https://hubmapconsortium.org/ent-4"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "hubmap:ent-4"
+              "@id": "https://hubmapconsortium.org/ent-4"
             }
           ]
         },
@@ -133,16 +133,16 @@
           "in_path": true
         },
         "prov": {
-          "prov:label": "ent-4"
+          "http://www.w3.org/ns/prov#label": "ent-4"
         }
       },
       {
-        "name": "hubmap:ent-7",
+        "name": "https://hubmapconsortium.org/ent-7",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "hubmap:ent-7"
+              "@id": "https://hubmapconsortium.org/ent-7"
             }
           ]
         },
@@ -151,30 +151,30 @@
           "in_path": true
         },
         "prov": {
-          "prov:label": "ent-7"
+          "http://www.w3.org/ns/prov#label": "ent-7"
         }
       }
     ],
     "prov": {
-      "prov:label": "act-2"
+      "http://www.w3.org/ns/prov#label": "act-2"
     }
   },
   {
-    "name": "hubmap:act-3",
+    "name": "https://hubmapconsortium.org/act-3",
     "inputs": [
       {
-        "name": "hubmap:ent-3",
+        "name": "https://hubmapconsortium.org/ent-3",
         "source": [
           {
-            "name": "hubmap:ent-3",
-            "for_file": "hubmap:ent-3",
-            "step": "hubmap:act-1"
+            "name": "https://hubmapconsortium.org/ent-3",
+            "for_file": "https://hubmapconsortium.org/ent-3",
+            "step": "https://hubmapconsortium.org/act-1"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "hubmap:ent-3"
+              "@id": "https://hubmapconsortium.org/ent-3"
             }
           ]
         },
@@ -184,18 +184,18 @@
           "type": "data file"
         },
         "prov": {
-          "prov:label": "ent-3"
+          "http://www.w3.org/ns/prov#label": "ent-3"
         }
       }
     ],
     "outputs": [
       {
-        "name": "hubmap:ent-5",
+        "name": "https://hubmapconsortium.org/ent-5",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "hubmap:ent-5"
+              "@id": "https://hubmapconsortium.org/ent-5"
             }
           ]
         },
@@ -204,29 +204,29 @@
           "in_path": true
         },
         "prov": {
-          "prov:label": "ent-5"
+          "http://www.w3.org/ns/prov#label": "ent-5"
         }
       }
     ],
     "prov": {
-      "prov:label": "act-3"
+      "http://www.w3.org/ns/prov#label": "act-3"
     }
   },
   {
-    "name": "hubmap:act-4",
+    "name": "https://hubmapconsortium.org/act-4",
     "inputs": [
       {
-        "name": "hubmap:ent-1",
+        "name": "https://hubmapconsortium.org/ent-1",
         "source": [
           {
-            "name": "hubmap:ent-1",
-            "for_file": "hubmap:ent-1"
+            "name": "https://hubmapconsortium.org/ent-1",
+            "for_file": "https://hubmapconsortium.org/ent-1"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "hubmap:ent-1"
+              "@id": "https://hubmapconsortium.org/ent-1"
             }
           ]
         },
@@ -236,22 +236,22 @@
           "type": "data file"
         },
         "prov": {
-          "prov:label": "ent-1"
+          "http://www.w3.org/ns/prov#label": "ent-1"
         }
       },
       {
-        "name": "hubmap:ent-3",
+        "name": "https://hubmapconsortium.org/ent-3",
         "source": [
           {
-            "name": "hubmap:ent-3",
-            "for_file": "hubmap:ent-3",
-            "step": "hubmap:act-1"
+            "name": "https://hubmapconsortium.org/ent-3",
+            "for_file": "https://hubmapconsortium.org/ent-3",
+            "step": "https://hubmapconsortium.org/act-1"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "hubmap:ent-3"
+              "@id": "https://hubmapconsortium.org/ent-3"
             }
           ]
         },
@@ -261,22 +261,22 @@
           "type": "data file"
         },
         "prov": {
-          "prov:label": "ent-3"
+          "http://www.w3.org/ns/prov#label": "ent-3"
         }
       },
       {
-        "name": "hubmap:ent-4",
+        "name": "https://hubmapconsortium.org/ent-4",
         "source": [
           {
-            "name": "hubmap:ent-4",
-            "for_file": "hubmap:ent-4",
-            "step": "hubmap:act-2"
+            "name": "https://hubmapconsortium.org/ent-4",
+            "for_file": "https://hubmapconsortium.org/ent-4",
+            "step": "https://hubmapconsortium.org/act-2"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "hubmap:ent-4"
+              "@id": "https://hubmapconsortium.org/ent-4"
             }
           ]
         },
@@ -286,18 +286,18 @@
           "type": "data file"
         },
         "prov": {
-          "prov:label": "ent-4"
+          "http://www.w3.org/ns/prov#label": "ent-4"
         }
       }
     ],
     "outputs": [
       {
-        "name": "hubmap:ent-6",
+        "name": "https://hubmapconsortium.org/ent-6",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "hubmap:ent-6"
+              "@id": "https://hubmapconsortium.org/ent-6"
             }
           ]
         },
@@ -306,12 +306,12 @@
           "in_path": true
         },
         "prov": {
-          "prov:label": "ent-6"
+          "http://www.w3.org/ns/prov#label": "ent-6"
         }
       }
     ],
     "prov": {
-      "prov:label": "act-4"
+      "http://www.w3.org/ns/prov#label": "act-4"
     }
   }
 ]

--- a/tests/fixtures/complex-cwl.json
+++ b/tests/fixtures/complex-cwl.json
@@ -1,19 +1,19 @@
 [
   {
-    "name": "https://hubmapconsortium.org/act-1",
+    "name": "act-1",
     "inputs": [
       {
-        "name": "https://hubmapconsortium.org/ent-1",
+        "name": "ent-1",
         "source": [
           {
-            "name": "https://hubmapconsortium.org/ent-1",
-            "for_file": "https://hubmapconsortium.org/ent-1"
+            "name": "ent-1",
+            "for_file": "ent-1"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/ent-1"
+              "@id": "ent-1"
             }
           ]
         },
@@ -29,21 +29,21 @@
     ],
     "outputs": [
       {
-        "name": "https://hubmapconsortium.org/ent-3",
+        "name": "ent-3",
         "target": [
           {
-            "step": "https://hubmapconsortium.org/act-3",
-            "name": "https://hubmapconsortium.org/ent-3"
+            "step": "act-3",
+            "name": "ent-3"
           },
           {
-            "step": "https://hubmapconsortium.org/act-4",
-            "name": "https://hubmapconsortium.org/ent-3"
+            "step": "act-4",
+            "name": "ent-3"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/ent-3"
+              "@id": "ent-3"
             }
           ]
         },
@@ -61,20 +61,20 @@
     }
   },
   {
-    "name": "https://hubmapconsortium.org/act-2",
+    "name": "act-2",
     "inputs": [
       {
-        "name": "https://hubmapconsortium.org/ent-1",
+        "name": "ent-1",
         "source": [
           {
-            "name": "https://hubmapconsortium.org/ent-1",
-            "for_file": "https://hubmapconsortium.org/ent-1"
+            "name": "ent-1",
+            "for_file": "ent-1"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/ent-1"
+              "@id": "ent-1"
             }
           ]
         },
@@ -88,17 +88,17 @@
         }
       },
       {
-        "name": "https://hubmapconsortium.org/ent-2",
+        "name": "ent-2",
         "source": [
           {
-            "name": "https://hubmapconsortium.org/ent-2",
-            "for_file": "https://hubmapconsortium.org/ent-2"
+            "name": "ent-2",
+            "for_file": "ent-2"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/ent-2"
+              "@id": "ent-2"
             }
           ]
         },
@@ -114,17 +114,17 @@
     ],
     "outputs": [
       {
-        "name": "https://hubmapconsortium.org/ent-4",
+        "name": "ent-4",
         "target": [
           {
-            "step": "https://hubmapconsortium.org/act-4",
-            "name": "https://hubmapconsortium.org/ent-4"
+            "step": "act-4",
+            "name": "ent-4"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/ent-4"
+              "@id": "ent-4"
             }
           ]
         },
@@ -137,12 +137,12 @@
         }
       },
       {
-        "name": "https://hubmapconsortium.org/ent-7",
+        "name": "ent-7",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/ent-7"
+              "@id": "ent-7"
             }
           ]
         },
@@ -160,21 +160,21 @@
     }
   },
   {
-    "name": "https://hubmapconsortium.org/act-3",
+    "name": "act-3",
     "inputs": [
       {
-        "name": "https://hubmapconsortium.org/ent-3",
+        "name": "ent-3",
         "source": [
           {
-            "name": "https://hubmapconsortium.org/ent-3",
-            "for_file": "https://hubmapconsortium.org/ent-3",
-            "step": "https://hubmapconsortium.org/act-1"
+            "name": "ent-3",
+            "for_file": "ent-3",
+            "step": "act-1"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/ent-3"
+              "@id": "ent-3"
             }
           ]
         },
@@ -190,12 +190,12 @@
     ],
     "outputs": [
       {
-        "name": "https://hubmapconsortium.org/ent-5",
+        "name": "ent-5",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/ent-5"
+              "@id": "ent-5"
             }
           ]
         },
@@ -213,20 +213,20 @@
     }
   },
   {
-    "name": "https://hubmapconsortium.org/act-4",
+    "name": "act-4",
     "inputs": [
       {
-        "name": "https://hubmapconsortium.org/ent-1",
+        "name": "ent-1",
         "source": [
           {
-            "name": "https://hubmapconsortium.org/ent-1",
-            "for_file": "https://hubmapconsortium.org/ent-1"
+            "name": "ent-1",
+            "for_file": "ent-1"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/ent-1"
+              "@id": "ent-1"
             }
           ]
         },
@@ -240,18 +240,18 @@
         }
       },
       {
-        "name": "https://hubmapconsortium.org/ent-3",
+        "name": "ent-3",
         "source": [
           {
-            "name": "https://hubmapconsortium.org/ent-3",
-            "for_file": "https://hubmapconsortium.org/ent-3",
-            "step": "https://hubmapconsortium.org/act-1"
+            "name": "ent-3",
+            "for_file": "ent-3",
+            "step": "act-1"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/ent-3"
+              "@id": "ent-3"
             }
           ]
         },
@@ -265,18 +265,18 @@
         }
       },
       {
-        "name": "https://hubmapconsortium.org/ent-4",
+        "name": "ent-4",
         "source": [
           {
-            "name": "https://hubmapconsortium.org/ent-4",
-            "for_file": "https://hubmapconsortium.org/ent-4",
-            "step": "https://hubmapconsortium.org/act-2"
+            "name": "ent-4",
+            "for_file": "ent-4",
+            "step": "act-2"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/ent-4"
+              "@id": "ent-4"
             }
           ]
         },
@@ -292,12 +292,12 @@
     ],
     "outputs": [
       {
-        "name": "https://hubmapconsortium.org/ent-6",
+        "name": "ent-6",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/ent-6"
+              "@id": "ent-6"
             }
           ]
         },

--- a/tests/fixtures/complex-prov.js
+++ b/tests/fixtures/complex-prov.js
@@ -14,7 +14,8 @@ export default {
   /* eslint-disable object-curly-newline */
   /* eslint-disable indent */
   prefix: {
-    hubmap: 'https://hubmapconsortium.org',
+    hubmap: 'https://hubmapconsortium.org/',
+    prov: 'http://www.w3.org/ns/prov#'
   },
   entity: {
     'hubmap:ent-1': { 'prov:label': 'ent-1' },

--- a/tests/fixtures/complex-prov.js
+++ b/tests/fixtures/complex-prov.js
@@ -15,7 +15,7 @@ export default {
   /* eslint-disable indent */
   prefix: {
     hubmap: 'https://hubmapconsortium.org/',
-    prov: 'http://www.w3.org/ns/prov#'
+    prov: 'http://www.w3.org/ns/prov#',
   },
   entity: {
     'hubmap:ent-1': { 'prov:label': 'ent-1' },

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -1,4 +1,4 @@
-import { PROV_NS } from '../../src/Prov'
+import { PROV_NS } from '../../src/Prov';
 
 import realProv from './real-prov.json';
 import realCwl from './real-cwl.json';
@@ -24,7 +24,6 @@ export const complex = {
 export const real = {
   getNameForActivity: (id, prov) => {
     const activity = prov.activity[id];
-    console.log(activity, `${PROV_NS}type`);
     return `${activity[`${PROV_NS}type`]} - ${activity[`${PROV_NS}label`]}`;
   },
   getNameForEntity: (id, prov) => {
@@ -38,4 +37,4 @@ export const real = {
 };
 
 // The React demo references the default export.
-export default real;
+export default complex;

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -8,13 +8,15 @@ import simpleProv from './simple-prov';
 import simpleCwl from './simple-cwl.json';
 
 export const simple = {
-  getNameForActivity: (id) => 'X', //id.split('/').pop(),
-  getNameForEntity: (id) => id.split('/').pop(),
+  getNameForActivity: (id) => id.split('#').pop(),
+  getNameForEntity: (id) => id.split('#').pop(),
   prov: simpleProv,
   cwl: simpleCwl,
 };
 
 export const complex = {
+  getNameForActivity: (id) => id.split('/').pop(),
+  getNameForEntity: (id) => id.split('/').pop(),
   prov: complexProv,
   cwl: complexCwl,
 };
@@ -35,4 +37,4 @@ export const real = {
 };
 
 // The React demo references the default export.
-export default simple;
+export default real;

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -34,4 +34,4 @@ export const real = {
 };
 
 // The React demo references the default export.
-export default complex;
+export default simple;

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -1,4 +1,4 @@
-import PROV_NS from '../../src/Prov'
+import { PROV_NS } from '../../src/Prov'
 
 import realProv from './real-prov.json';
 import realCwl from './real-cwl.json';
@@ -24,6 +24,7 @@ export const complex = {
 export const real = {
   getNameForActivity: (id, prov) => {
     const activity = prov.activity[id];
+    console.log(activity, `${PROV_NS}type`);
     return `${activity[`${PROV_NS}type`]} - ${activity[`${PROV_NS}label`]}`;
   },
   getNameForEntity: (id, prov) => {

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -1,3 +1,5 @@
+import PROV_NS from '../../src/Prov'
+
 import realProv from './real-prov.json';
 import realCwl from './real-cwl.json';
 import complexProv from './complex-prov';
@@ -6,14 +8,13 @@ import simpleProv from './simple-prov';
 import simpleCwl from './simple-cwl.json';
 
 export const simple = {
-  getNameForActivity: (id) => id,
-  getNameForEntity: (id) => id,
+  getNameForActivity: (id) => 'X', //id.split('/').pop(),
+  getNameForEntity: (id) => id.split('/').pop(),
   prov: simpleProv,
   cwl: simpleCwl,
 };
 
 export const complex = {
-  getNameForActivity: (id) => id,
   prov: complexProv,
   cwl: complexCwl,
 };
@@ -21,13 +22,13 @@ export const complex = {
 export const real = {
   getNameForActivity: (id, prov) => {
     const activity = prov.activity[id];
-    return `${activity['prov:type']} - ${activity['prov:label']}`;
+    return `${activity[`${PROV_NS}type`]} - ${activity[`${PROV_NS}label`]}`;
   },
   getNameForEntity: (id, prov) => {
     const entity = prov.entity[id];
     // NOTE: The initial entity node was not included in the sample data;
     // Fallback to ID, if needed. https://github.com/hubmapconsortium/prov-vis/issues/15
-    return entity ? `${entity['prov:type']} - ${entity['prov:label']}` : id;
+    return entity ? `${entity[`${PROV_NS}type`]} - ${entity[`${PROV_NS}label`]}` : id;
   },
   prov: realProv,
   cwl: realCwl,

--- a/tests/fixtures/real-cwl.json
+++ b/tests/fixtures/real-cwl.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "https://hubmapconsortium.org/activities/822a66f8d498ef37fbc2280abcf56c9e",
+    "name": "Create Sample Activity - 822a66f8d498ef37fbc2280abcf56c9e",
     "inputs": [
       {
         "name": "https://hubmapconsortium.org/entities/9942c58c009cb0a0f245f9cb61586af5",
@@ -27,12 +27,12 @@
     ],
     "outputs": [
       {
-        "name": "https://hubmapconsortium.org/entities/0817f6a3a2f170486a49f2ffae46072d",
+        "name": "Sample - TEST0005-RK-4",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/entities/0817f6a3a2f170486a49f2ffae46072d"
+              "@id": "Sample - TEST0005-RK-4"
             }
           ]
         },
@@ -44,21 +44,21 @@
           "http://www.w3.org/ns/prov#label": "TEST0005-RK-4",
           "http://www.w3.org/ns/prov#type": "Sample",
           "https://hubmapconsortium.org/doi": "576RGJR357",
-          "https://hubmapconsortium.org/displayDOI": "undefined576-RGJR-357",
+          "https://hubmapconsortium.org/displayDOI": "HBM:576-RGJR-357",
           "https://hubmapconsortium.org/displayIdentifier": "TEST0005-RK-4",
           "https://hubmapconsortium.org/uuid": "0817f6a3a2f170486a49f2ffae46072d",
-          "https://hubmapconsortium.org/metadata": "undefined \"[{'id'",
-          "http://www.w3.org/ns/prov#generatedAtTime": "undefined40",
-          "https://hubmapconsortium.org/modifiedTimestamp": "undefined40"
+          "https://hubmapconsortium.org/metadata": "{\"protocols\": \"[{'id': 'protocol_1', 'protocol_url': 'http://protocols.io/protst/29022928394', 'protocol_file': ''}]\", \"specimen_type\": \"fresh_frozen_tissue\", \"user_group_uuid\": \"5bd084c8-edc2-11e8-802f-0e368f3075e8\", \"sample_count\": \"5\"}",
+          "http://www.w3.org/ns/prov#generatedAtTime": "2019-09-17T16:40:04",
+          "https://hubmapconsortium.org/modifiedTimestamp": "2019-09-17T16:40:04"
         }
       },
       {
-        "name": "https://hubmapconsortium.org/entities/12e77e69ab76b1832a95e00646f666db",
+        "name": "Sample - TEST0005-RK-5",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/entities/12e77e69ab76b1832a95e00646f666db"
+              "@id": "Sample - TEST0005-RK-5"
             }
           ]
         },
@@ -70,21 +70,21 @@
           "http://www.w3.org/ns/prov#label": "TEST0005-RK-5",
           "http://www.w3.org/ns/prov#type": "Sample",
           "https://hubmapconsortium.org/doi": "555JCVC476",
-          "https://hubmapconsortium.org/displayDOI": "undefined555-JCVC-476",
+          "https://hubmapconsortium.org/displayDOI": "HBM:555-JCVC-476",
           "https://hubmapconsortium.org/displayIdentifier": "TEST0005-RK-5",
           "https://hubmapconsortium.org/uuid": "12e77e69ab76b1832a95e00646f666db",
-          "https://hubmapconsortium.org/metadata": "undefined \"[{'id'",
-          "http://www.w3.org/ns/prov#generatedAtTime": "undefined40",
-          "https://hubmapconsortium.org/modifiedTimestamp": "undefined40"
+          "https://hubmapconsortium.org/metadata": "{\"protocols\": \"[{'id': 'protocol_1', 'protocol_url': 'http://protocols.io/protst/29022928394', 'protocol_file': ''}]\", \"specimen_type\": \"fresh_frozen_tissue\", \"user_group_uuid\": \"5bd084c8-edc2-11e8-802f-0e368f3075e8\", \"sample_count\": \"5\"}",
+          "http://www.w3.org/ns/prov#generatedAtTime": "2019-09-17T16:40:04",
+          "https://hubmapconsortium.org/modifiedTimestamp": "2019-09-17T16:40:04"
         }
       },
       {
-        "name": "https://hubmapconsortium.org/entities/d2f87dda666fce9efeeeb09b078b5feb",
+        "name": "Sample - TEST0005-RK-3",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/entities/d2f87dda666fce9efeeeb09b078b5feb"
+              "@id": "Sample - TEST0005-RK-3"
             }
           ]
         },
@@ -96,21 +96,21 @@
           "http://www.w3.org/ns/prov#label": "TEST0005-RK-3",
           "http://www.w3.org/ns/prov#type": "Sample",
           "https://hubmapconsortium.org/doi": "479XQZH692",
-          "https://hubmapconsortium.org/displayDOI": "undefined479-XQZH-692",
+          "https://hubmapconsortium.org/displayDOI": "HBM:479-XQZH-692",
           "https://hubmapconsortium.org/displayIdentifier": "TEST0005-RK-3",
           "https://hubmapconsortium.org/uuid": "d2f87dda666fce9efeeeb09b078b5feb",
-          "https://hubmapconsortium.org/metadata": "undefined \"[{'id'",
-          "http://www.w3.org/ns/prov#generatedAtTime": "undefined40",
-          "https://hubmapconsortium.org/modifiedTimestamp": "undefined40"
+          "https://hubmapconsortium.org/metadata": "{\"protocols\": \"[{'id': 'protocol_1', 'protocol_url': 'http://protocols.io/protst/29022928394', 'protocol_file': ''}]\", \"specimen_type\": \"fresh_frozen_tissue\", \"user_group_uuid\": \"5bd084c8-edc2-11e8-802f-0e368f3075e8\", \"sample_count\": \"5\"}",
+          "http://www.w3.org/ns/prov#generatedAtTime": "2019-09-17T16:40:04",
+          "https://hubmapconsortium.org/modifiedTimestamp": "2019-09-17T16:40:04"
         }
       },
       {
-        "name": "https://hubmapconsortium.org/entities/731c5b88cdc623212cf605d1ff6f22f7",
+        "name": "Sample - TEST0005-RK-2",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/entities/731c5b88cdc623212cf605d1ff6f22f7"
+              "@id": "Sample - TEST0005-RK-2"
             }
           ]
         },
@@ -122,21 +122,21 @@
           "http://www.w3.org/ns/prov#label": "TEST0005-RK-2",
           "http://www.w3.org/ns/prov#type": "Sample",
           "https://hubmapconsortium.org/doi": "876VBCH275",
-          "https://hubmapconsortium.org/displayDOI": "undefined876-VBCH-275",
+          "https://hubmapconsortium.org/displayDOI": "HBM:876-VBCH-275",
           "https://hubmapconsortium.org/displayIdentifier": "TEST0005-RK-2",
           "https://hubmapconsortium.org/uuid": "731c5b88cdc623212cf605d1ff6f22f7",
-          "https://hubmapconsortium.org/metadata": "undefined \"[{'id'",
-          "http://www.w3.org/ns/prov#generatedAtTime": "undefined40",
-          "https://hubmapconsortium.org/modifiedTimestamp": "undefined40"
+          "https://hubmapconsortium.org/metadata": "{\"protocols\": \"[{'id': 'protocol_1', 'protocol_url': 'http://protocols.io/protst/29022928394', 'protocol_file': ''}]\", \"specimen_type\": \"fresh_frozen_tissue\", \"user_group_uuid\": \"5bd084c8-edc2-11e8-802f-0e368f3075e8\", \"sample_count\": \"5\"}",
+          "http://www.w3.org/ns/prov#generatedAtTime": "2019-09-17T16:40:04",
+          "https://hubmapconsortium.org/modifiedTimestamp": "2019-09-17T16:40:04"
         }
       },
       {
-        "name": "https://hubmapconsortium.org/entities/51318fa4fff79c82d4de7b2d70e630cb",
+        "name": "Sample - TEST0005-RK-1",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "https://hubmapconsortium.org/entities/51318fa4fff79c82d4de7b2d70e630cb"
+              "@id": "Sample - TEST0005-RK-1"
             }
           ]
         },
@@ -148,26 +148,26 @@
           "http://www.w3.org/ns/prov#label": "TEST0005-RK-1",
           "http://www.w3.org/ns/prov#type": "Sample",
           "https://hubmapconsortium.org/doi": "836PZMN835",
-          "https://hubmapconsortium.org/displayDOI": "undefined836-PZMN-835",
+          "https://hubmapconsortium.org/displayDOI": "HBM:836-PZMN-835",
           "https://hubmapconsortium.org/displayIdentifier": "TEST0005-RK-1",
           "https://hubmapconsortium.org/uuid": "51318fa4fff79c82d4de7b2d70e630cb",
-          "https://hubmapconsortium.org/metadata": "undefined \"[{'id'",
-          "http://www.w3.org/ns/prov#generatedAtTime": "undefined40",
-          "https://hubmapconsortium.org/modifiedTimestamp": "undefined40"
+          "https://hubmapconsortium.org/metadata": "{\"protocols\": \"[{'id': 'protocol_1', 'protocol_url': 'http://protocols.io/protst/29022928394', 'protocol_file': ''}]\", \"specimen_type\": \"fresh_frozen_tissue\", \"user_group_uuid\": \"5bd084c8-edc2-11e8-802f-0e368f3075e8\", \"sample_count\": \"5\"}",
+          "http://www.w3.org/ns/prov#generatedAtTime": "2019-09-17T16:40:04",
+          "https://hubmapconsortium.org/modifiedTimestamp": "2019-09-17T16:40:04"
         }
       }
     ],
     "prov": {
-      "http://www.w3.org/ns/prov#startTime": "undefined40",
-      "http://www.w3.org/ns/prov#endTime": "undefined40",
+      "http://www.w3.org/ns/prov#startTime": "2019-09-17T16:40:04",
+      "http://www.w3.org/ns/prov#endTime": "2019-09-17T16:40:04",
       "http://www.w3.org/ns/prov#label": "822a66f8d498ef37fbc2280abcf56c9e",
       "http://www.w3.org/ns/prov#type": "Create Sample Activity",
       "https://hubmapconsortium.org/doi": "982TNDD845",
-      "https://hubmapconsortium.org/displayDOI": "undefined982-TNDD-845",
+      "https://hubmapconsortium.org/displayDOI": "HBM:982-TNDD-845",
       "https://hubmapconsortium.org/displayIdentifier": "822a66f8d498ef37fbc2280abcf56c9e",
       "https://hubmapconsortium.org/uuid": "822a66f8d498ef37fbc2280abcf56c9e",
-      "http://www.w3.org/ns/prov#generatedAtTime": "undefined40",
-      "https://hubmapconsortium.org/modifiedTimestamp": "undefined40"
+      "http://www.w3.org/ns/prov#generatedAtTime": "2019-09-17T16:40:04",
+      "https://hubmapconsortium.org/modifiedTimestamp": "2019-09-17T16:40:04"
     }
   }
 ]

--- a/tests/fixtures/real-cwl.json
+++ b/tests/fixtures/real-cwl.json
@@ -1,19 +1,19 @@
 [
   {
-    "name": "Create Sample Activity - 822a66f8d498ef37fbc2280abcf56c9e",
+    "name": "https://hubmapconsortium.org/activities/822a66f8d498ef37fbc2280abcf56c9e",
     "inputs": [
       {
-        "name": "hubmap:entities/9942c58c009cb0a0f245f9cb61586af5",
+        "name": "https://hubmapconsortium.org/entities/9942c58c009cb0a0f245f9cb61586af5",
         "source": [
           {
-            "name": "hubmap:entities/9942c58c009cb0a0f245f9cb61586af5",
-            "for_file": "hubmap:entities/9942c58c009cb0a0f245f9cb61586af5"
+            "name": "https://hubmapconsortium.org/entities/9942c58c009cb0a0f245f9cb61586af5",
+            "for_file": "https://hubmapconsortium.org/entities/9942c58c009cb0a0f245f9cb61586af5"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "hubmap:entities/9942c58c009cb0a0f245f9cb61586af5"
+              "@id": "https://hubmapconsortium.org/entities/9942c58c009cb0a0f245f9cb61586af5"
             }
           ]
         },
@@ -27,12 +27,12 @@
     ],
     "outputs": [
       {
-        "name": "Sample - TEST0005-RK-4",
+        "name": "https://hubmapconsortium.org/entities/0817f6a3a2f170486a49f2ffae46072d",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "Sample - TEST0005-RK-4"
+              "@id": "https://hubmapconsortium.org/entities/0817f6a3a2f170486a49f2ffae46072d"
             }
           ]
         },
@@ -41,24 +41,24 @@
           "in_path": true
         },
         "prov": {
-          "prov:label": "TEST0005-RK-4",
-          "prov:type": "Sample",
-          "hubmap:doi": "576RGJR357",
-          "hubmap:displayDOI": "HBM:576-RGJR-357",
-          "hubmap:displayIdentifier": "TEST0005-RK-4",
-          "hubmap:uuid": "0817f6a3a2f170486a49f2ffae46072d",
-          "hubmap:metadata": "{\"protocols\": \"[{'id': 'protocol_1', 'protocol_url': 'http://protocols.io/protst/29022928394', 'protocol_file': ''}]\", \"specimen_type\": \"fresh_frozen_tissue\", \"user_group_uuid\": \"5bd084c8-edc2-11e8-802f-0e368f3075e8\", \"sample_count\": \"5\"}",
-          "prov:generatedAtTime": "2019-09-17T16:40:04",
-          "hubmap:modifiedTimestamp": "2019-09-17T16:40:04"
+          "http://www.w3.org/ns/prov#label": "TEST0005-RK-4",
+          "http://www.w3.org/ns/prov#type": "Sample",
+          "https://hubmapconsortium.org/doi": "576RGJR357",
+          "https://hubmapconsortium.org/displayDOI": "undefined576-RGJR-357",
+          "https://hubmapconsortium.org/displayIdentifier": "TEST0005-RK-4",
+          "https://hubmapconsortium.org/uuid": "0817f6a3a2f170486a49f2ffae46072d",
+          "https://hubmapconsortium.org/metadata": "undefined \"[{'id'",
+          "http://www.w3.org/ns/prov#generatedAtTime": "undefined40",
+          "https://hubmapconsortium.org/modifiedTimestamp": "undefined40"
         }
       },
       {
-        "name": "Sample - TEST0005-RK-5",
+        "name": "https://hubmapconsortium.org/entities/12e77e69ab76b1832a95e00646f666db",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "Sample - TEST0005-RK-5"
+              "@id": "https://hubmapconsortium.org/entities/12e77e69ab76b1832a95e00646f666db"
             }
           ]
         },
@@ -67,24 +67,24 @@
           "in_path": true
         },
         "prov": {
-          "prov:label": "TEST0005-RK-5",
-          "prov:type": "Sample",
-          "hubmap:doi": "555JCVC476",
-          "hubmap:displayDOI": "HBM:555-JCVC-476",
-          "hubmap:displayIdentifier": "TEST0005-RK-5",
-          "hubmap:uuid": "12e77e69ab76b1832a95e00646f666db",
-          "hubmap:metadata": "{\"protocols\": \"[{'id': 'protocol_1', 'protocol_url': 'http://protocols.io/protst/29022928394', 'protocol_file': ''}]\", \"specimen_type\": \"fresh_frozen_tissue\", \"user_group_uuid\": \"5bd084c8-edc2-11e8-802f-0e368f3075e8\", \"sample_count\": \"5\"}",
-          "prov:generatedAtTime": "2019-09-17T16:40:04",
-          "hubmap:modifiedTimestamp": "2019-09-17T16:40:04"
+          "http://www.w3.org/ns/prov#label": "TEST0005-RK-5",
+          "http://www.w3.org/ns/prov#type": "Sample",
+          "https://hubmapconsortium.org/doi": "555JCVC476",
+          "https://hubmapconsortium.org/displayDOI": "undefined555-JCVC-476",
+          "https://hubmapconsortium.org/displayIdentifier": "TEST0005-RK-5",
+          "https://hubmapconsortium.org/uuid": "12e77e69ab76b1832a95e00646f666db",
+          "https://hubmapconsortium.org/metadata": "undefined \"[{'id'",
+          "http://www.w3.org/ns/prov#generatedAtTime": "undefined40",
+          "https://hubmapconsortium.org/modifiedTimestamp": "undefined40"
         }
       },
       {
-        "name": "Sample - TEST0005-RK-3",
+        "name": "https://hubmapconsortium.org/entities/d2f87dda666fce9efeeeb09b078b5feb",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "Sample - TEST0005-RK-3"
+              "@id": "https://hubmapconsortium.org/entities/d2f87dda666fce9efeeeb09b078b5feb"
             }
           ]
         },
@@ -93,24 +93,24 @@
           "in_path": true
         },
         "prov": {
-          "prov:label": "TEST0005-RK-3",
-          "prov:type": "Sample",
-          "hubmap:doi": "479XQZH692",
-          "hubmap:displayDOI": "HBM:479-XQZH-692",
-          "hubmap:displayIdentifier": "TEST0005-RK-3",
-          "hubmap:uuid": "d2f87dda666fce9efeeeb09b078b5feb",
-          "hubmap:metadata": "{\"protocols\": \"[{'id': 'protocol_1', 'protocol_url': 'http://protocols.io/protst/29022928394', 'protocol_file': ''}]\", \"specimen_type\": \"fresh_frozen_tissue\", \"user_group_uuid\": \"5bd084c8-edc2-11e8-802f-0e368f3075e8\", \"sample_count\": \"5\"}",
-          "prov:generatedAtTime": "2019-09-17T16:40:04",
-          "hubmap:modifiedTimestamp": "2019-09-17T16:40:04"
+          "http://www.w3.org/ns/prov#label": "TEST0005-RK-3",
+          "http://www.w3.org/ns/prov#type": "Sample",
+          "https://hubmapconsortium.org/doi": "479XQZH692",
+          "https://hubmapconsortium.org/displayDOI": "undefined479-XQZH-692",
+          "https://hubmapconsortium.org/displayIdentifier": "TEST0005-RK-3",
+          "https://hubmapconsortium.org/uuid": "d2f87dda666fce9efeeeb09b078b5feb",
+          "https://hubmapconsortium.org/metadata": "undefined \"[{'id'",
+          "http://www.w3.org/ns/prov#generatedAtTime": "undefined40",
+          "https://hubmapconsortium.org/modifiedTimestamp": "undefined40"
         }
       },
       {
-        "name": "Sample - TEST0005-RK-2",
+        "name": "https://hubmapconsortium.org/entities/731c5b88cdc623212cf605d1ff6f22f7",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "Sample - TEST0005-RK-2"
+              "@id": "https://hubmapconsortium.org/entities/731c5b88cdc623212cf605d1ff6f22f7"
             }
           ]
         },
@@ -119,24 +119,24 @@
           "in_path": true
         },
         "prov": {
-          "prov:label": "TEST0005-RK-2",
-          "prov:type": "Sample",
-          "hubmap:doi": "876VBCH275",
-          "hubmap:displayDOI": "HBM:876-VBCH-275",
-          "hubmap:displayIdentifier": "TEST0005-RK-2",
-          "hubmap:uuid": "731c5b88cdc623212cf605d1ff6f22f7",
-          "hubmap:metadata": "{\"protocols\": \"[{'id': 'protocol_1', 'protocol_url': 'http://protocols.io/protst/29022928394', 'protocol_file': ''}]\", \"specimen_type\": \"fresh_frozen_tissue\", \"user_group_uuid\": \"5bd084c8-edc2-11e8-802f-0e368f3075e8\", \"sample_count\": \"5\"}",
-          "prov:generatedAtTime": "2019-09-17T16:40:04",
-          "hubmap:modifiedTimestamp": "2019-09-17T16:40:04"
+          "http://www.w3.org/ns/prov#label": "TEST0005-RK-2",
+          "http://www.w3.org/ns/prov#type": "Sample",
+          "https://hubmapconsortium.org/doi": "876VBCH275",
+          "https://hubmapconsortium.org/displayDOI": "undefined876-VBCH-275",
+          "https://hubmapconsortium.org/displayIdentifier": "TEST0005-RK-2",
+          "https://hubmapconsortium.org/uuid": "731c5b88cdc623212cf605d1ff6f22f7",
+          "https://hubmapconsortium.org/metadata": "undefined \"[{'id'",
+          "http://www.w3.org/ns/prov#generatedAtTime": "undefined40",
+          "https://hubmapconsortium.org/modifiedTimestamp": "undefined40"
         }
       },
       {
-        "name": "Sample - TEST0005-RK-1",
+        "name": "https://hubmapconsortium.org/entities/51318fa4fff79c82d4de7b2d70e630cb",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "Sample - TEST0005-RK-1"
+              "@id": "https://hubmapconsortium.org/entities/51318fa4fff79c82d4de7b2d70e630cb"
             }
           ]
         },
@@ -145,29 +145,29 @@
           "in_path": true
         },
         "prov": {
-          "prov:label": "TEST0005-RK-1",
-          "prov:type": "Sample",
-          "hubmap:doi": "836PZMN835",
-          "hubmap:displayDOI": "HBM:836-PZMN-835",
-          "hubmap:displayIdentifier": "TEST0005-RK-1",
-          "hubmap:uuid": "51318fa4fff79c82d4de7b2d70e630cb",
-          "hubmap:metadata": "{\"protocols\": \"[{'id': 'protocol_1', 'protocol_url': 'http://protocols.io/protst/29022928394', 'protocol_file': ''}]\", \"specimen_type\": \"fresh_frozen_tissue\", \"user_group_uuid\": \"5bd084c8-edc2-11e8-802f-0e368f3075e8\", \"sample_count\": \"5\"}",
-          "prov:generatedAtTime": "2019-09-17T16:40:04",
-          "hubmap:modifiedTimestamp": "2019-09-17T16:40:04"
+          "http://www.w3.org/ns/prov#label": "TEST0005-RK-1",
+          "http://www.w3.org/ns/prov#type": "Sample",
+          "https://hubmapconsortium.org/doi": "836PZMN835",
+          "https://hubmapconsortium.org/displayDOI": "undefined836-PZMN-835",
+          "https://hubmapconsortium.org/displayIdentifier": "TEST0005-RK-1",
+          "https://hubmapconsortium.org/uuid": "51318fa4fff79c82d4de7b2d70e630cb",
+          "https://hubmapconsortium.org/metadata": "undefined \"[{'id'",
+          "http://www.w3.org/ns/prov#generatedAtTime": "undefined40",
+          "https://hubmapconsortium.org/modifiedTimestamp": "undefined40"
         }
       }
     ],
     "prov": {
-      "prov:startTime": "2019-09-17T16:40:04",
-      "prov:endTime": "2019-09-17T16:40:04",
-      "prov:label": "822a66f8d498ef37fbc2280abcf56c9e",
-      "prov:type": "Create Sample Activity",
-      "hubmap:doi": "982TNDD845",
-      "hubmap:displayDOI": "HBM:982-TNDD-845",
-      "hubmap:displayIdentifier": "822a66f8d498ef37fbc2280abcf56c9e",
-      "hubmap:uuid": "822a66f8d498ef37fbc2280abcf56c9e",
-      "prov:generatedAtTime": "2019-09-17T16:40:04",
-      "hubmap:modifiedTimestamp": "2019-09-17T16:40:04"
+      "http://www.w3.org/ns/prov#startTime": "undefined40",
+      "http://www.w3.org/ns/prov#endTime": "undefined40",
+      "http://www.w3.org/ns/prov#label": "822a66f8d498ef37fbc2280abcf56c9e",
+      "http://www.w3.org/ns/prov#type": "Create Sample Activity",
+      "https://hubmapconsortium.org/doi": "982TNDD845",
+      "https://hubmapconsortium.org/displayDOI": "undefined982-TNDD-845",
+      "https://hubmapconsortium.org/displayIdentifier": "822a66f8d498ef37fbc2280abcf56c9e",
+      "https://hubmapconsortium.org/uuid": "822a66f8d498ef37fbc2280abcf56c9e",
+      "http://www.w3.org/ns/prov#generatedAtTime": "undefined40",
+      "https://hubmapconsortium.org/modifiedTimestamp": "undefined40"
     }
   }
 ]

--- a/tests/fixtures/real-prov.json
+++ b/tests/fixtures/real-prov.json
@@ -3,7 +3,8 @@
     "ex": "http://example.org/",
     "hubmap": "https://hubmapconsortium.org/",
     "dct": "http://purl.org/dc/terms/",
-    "foaf": "http://xmlns.com/foaf/0.1/"
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "prov": "http://www.w3.org/ns/prov#"
   },
   "agent": {
     "hubmap:agent/e19adbbb-73c3-43a7-b05e-0eead04f5ff8": {

--- a/tests/fixtures/simple-cwl.json
+++ b/tests/fixtures/simple-cwl.json
@@ -1,19 +1,19 @@
 [
   {
-    "name": "http://example.com#process",
+    "name": "process",
     "inputs": [
       {
-        "name": "http://example.com#input",
+        "name": "input",
         "source": [
           {
-            "name": "http://example.com#input",
-            "for_file": "http://example.com#input"
+            "name": "input",
+            "for_file": "input"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "http://example.com#input"
+              "@id": "input"
             }
           ]
         },
@@ -30,12 +30,12 @@
     ],
     "outputs": [
       {
-        "name": "http://example.com#output",
+        "name": "output",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "http://example.com#output"
+              "@id": "output"
             }
           ]
         },

--- a/tests/fixtures/simple-cwl.json
+++ b/tests/fixtures/simple-cwl.json
@@ -1,19 +1,19 @@
 [
   {
-    "name": "ex:process",
+    "name": "http://example.com#process",
     "inputs": [
       {
-        "name": "ex:input",
+        "name": "http://example.com#input",
         "source": [
           {
-            "name": "ex:input",
-            "for_file": "ex:input"
+            "name": "http://example.com#input",
+            "for_file": "http://example.com#input"
           }
         ],
         "run_data": {
           "file": [
             {
-              "@id": "ex:input"
+              "@id": "http://example.com#input"
             }
           ]
         },
@@ -23,19 +23,19 @@
           "type": "data file"
         },
         "prov": {
-          "prov:label": "Input",
-          "ex:note": "Begins here..."
+          "http://www.w3.org/ns/prov#label": "Input",
+          "http://example.com#note": "Begins here..."
         }
       }
     ],
     "outputs": [
       {
-        "name": "ex:output",
+        "name": "http://example.com#output",
         "target": [],
         "run_data": {
           "file": [
             {
-              "@id": "ex:output"
+              "@id": "http://example.com#output"
             }
           ]
         },
@@ -44,13 +44,13 @@
           "in_path": true
         },
         "prov": {
-          "prov:label": "Output",
-          "ex:note": "... and ends here."
+          "http://www.w3.org/ns/prov#label": "Output",
+          "http://example.com#note": "... and ends here."
         }
       }
     ],
     "prov": {
-      "prov:label": "Process"
+      "http://www.w3.org/ns/prov#label": "Process"
     }
   }
 ]

--- a/tests/fixtures/simple-prov.js
+++ b/tests/fixtures/simple-prov.js
@@ -2,7 +2,8 @@
 
 export default {
   prefix: {
-    ex: 'http://example.com',
+    ex: 'http://example.com#',
+    prov: 'http://www.w3.org/ns/prov#'
   },
   entity: {
     'ex:input': { 'prov:label': 'Input', 'ex:note': 'Begins here...' },

--- a/tests/fixtures/simple-prov.js
+++ b/tests/fixtures/simple-prov.js
@@ -3,7 +3,7 @@
 export default {
   prefix: {
     ex: 'http://example.com#',
-    prov: 'http://www.w3.org/ns/prov#'
+    prov: 'http://www.w3.org/ns/prov#',
   },
   entity: {
     'ex:input': { 'prov:label': 'Input', 'ex:note': 'Begins here...' },


### PR DESCRIPTION
Fix #26: The NS prefixes are arbitrary; Now, we expand them to the full URIs in the CWL.

There are going to be a few more things of this type, where we have what is essentially a `Prov` object, but some clean-up is necessary. To support this, in this PR, I added an `expandPrefixes()` method, which returns a new `Prov` object.

There are other ways this could be done:
- Put it all in the constructor.
- Create different types of objects, for the different phases of the clean up.
- Provide utility methods that do different phases of the clean-up.

(The transformation itself in this case is kind of messy: At first I thought recursion would solve everything, but the special cases that need be handled suggest it should have been written out flat to begin with?)