### PR TITLE
Add non .js files to es build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Changed
 - Fixed redundant fixtures.
 - Namespace prefixes are arbitrary: This expands them to the URIs they represent.
--- Modify npm build script to include non .js files included in src in ES module.
+- Modify npm build script to include non .js files included in src in ES module.
 
 ## [0.0.2](https://www.npmjs.com/package/@hubmap/prov-vis/v/0.0.2) - 2019-11-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 - Fixed redundant fixtures.
 - Namespace prefixes are arbitrary: This expands them to the URIs they represent.
+-- Modify npm build script to include non .js files included in src in ES module.
 
 ## [0.0.2](https://www.npmjs.com/package/@hubmap/prov-vis/v/0.0.2) - 2019-11-04
 ### Added

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "umd"
   ],
   "scripts": {
-    "build": "nwb build-react-component",
+    "build": "nwb build-react-component --copy-files",
     "clean": "nwb clean-module && nwb clean-demo",
     "prepublishOnly": "npm run build",
     "start": "nwb serve-react-demo",


### PR DESCRIPTION
Modified build script in package.json to include non .js files in es module. Will revisit the issue once corresponding changes to portal-ui have been made and everything is confirmed to be working end-to-end.